### PR TITLE
Change the database-reference from 'db' to 'collections_db_1'

### DIFF
--- a/collections-api/src/main/resources/project-mysql.yaml
+++ b/collections-api/src/main/resources/project-mysql.yaml
@@ -10,6 +10,6 @@ swarm:
     data-sources:
       DinaDS:
         driver-name: com.mysql
-        connection-url: jdbc:mysql://db:3306/dina_collections?autoReconnect=true&useSSL=false
+        connection-url: jdbc:mysql://collections_db_1:3306/dina_collections?autoReconnect=true&useSSL=false
         user-name: admin
         password: password12


### PR DESCRIPTION
changing the reference in the collections-api/src/main/resources/project-mysql.yaml-file
from 'db' to 'collections_db_1' - due to the fact that more than one database has the id 'db' on the proxy-network.