### PR TITLE
Ingimar/refactoring the test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ env/.envaccounts
 env/.envmysql
 
 *~
+*.log

--- a/scripts/alpha_testing_response.sh
+++ b/scripts/alpha_testing_response.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # able to check the TOKEN here -> https://jwt.io/ 
 source .env
+dt=$(date '+%Y-%m-%d %H:%M:%S');
+echo $dt
+
 EXPECTED_RESULT="Hello from collections api"
 
 
@@ -22,6 +25,12 @@ echo ""
 echo "Response from ${ALPHA_SERVER} is \"$RESPONSE\" "
 [ "$RESPONSE" == "$EXPECTED_RESULT" ] && echo "TRUE : correct response " || echo "FALSE: wrong response"
 echo ""
+
+# writing to a log file
+echo "$dt">> script.log
+echo "Token is fetched from $KEYCLOAK_SERVER" >> script.log
+echo "Response from the ${ALPHA_SERVER} is \"$RESPONSE\" " >>script.log
+echo "" >>script.log
 
 
 

--- a/scripts/alpha_testing_response.sh
+++ b/scripts/alpha_testing_response.sh
@@ -1,18 +1,30 @@
 #!/bin/bash
+# able to check the TOKEN here -> https://jwt.io/ 
 source .env
+EXPECTED_RESULT="Hello from collections api"
 
-KEYCLOAK_SERVER=https://alpha-keycloak.dina-web.net/auth/realms/dina/protocol/openid-connect/token
+
+#KEYCLOAK_SERVER=https://alpha-keycloak.dina-web.net/auth/realms/dina/protocol/openid-connect/token
+KEYCLOAK_SERVER=https://alpha-cm.dina-web.net/auth/realms/dina/protocol/openid-connect/token ## testing, anton has a 'routing'
 ALPHA_SERVER=https://alpha-api.dina-web.net
 
 RESULT=`curl --data "grant_type=password&client_id=${client_id}&username=${username}&password=${password}" $KEYCLOAK_SERVER`
 TOKEN=`echo $RESULT | sed 's/.*access_token":"//g' | sed 's/".*//g'`
 
-RESPONSE=`curl -H "Authorization: bearer $TOKEN" ${ALPHA_SERVER}/collections/api/v01`
-EXPECTED_RESULT="Hello from collections api"
+# able to pass in '-v' for verbose 
+if [ $1 = "-v" ]; then
+   RESPONSE=`curl -vH "Authorization: bearer $TOKEN" ${ALPHA_SERVER}/collections/api/v01`
+else
+   RESPONSE=`curl -H "Authorization: bearer $TOKEN" ${ALPHA_SERVER}/collections/api/v01`
+fi
 
 echo ""
 echo "Response from ${ALPHA_SERVER} is \"$RESPONSE\" "
 [ "$RESPONSE" == "$EXPECTED_RESULT" ] && echo "TRUE : correct response " || echo "FALSE: wrong response"
 echo ""
+
+
+
+#echo $TOKEN
 
 exit 0


### PR DESCRIPTION
Feature, able to send in the argument '-v' ( ./scripts/alpha_testing_response.sh -v ) that turns on the verbose flag for curl showing the headers.
Feature, saves a log every time the script is ran with info where the token is fetched from and the content of the RESPONSE-variable.